### PR TITLE
Implementation of a "collapsible" option to hide advanced options.

### DIFF
--- a/gooey/gui/components/collapsible_group.py
+++ b/gooey/gui/components/collapsible_group.py
@@ -1,0 +1,52 @@
+import wx
+from gooey.gui.util import wx_util
+
+
+class CollapsibleGroup(wx.CollapsiblePane):
+    def __init__(self, parent, *args, groupName, groupDescription, showBorders, **kwargs):
+        super(CollapsibleGroup, self).__init__(parent, *args, **kwargs, style=wx.CP_NO_TLW_RESIZE, label=groupName)
+        # In order to be visible even when collapsed, the group name must be but in the CollapsiblePane's label.
+        # To be consistant with the OptionGroups widget, h1 styling must be applied to the label,
+        #  and the only way is to apply it to the whole wx.CollapsiblePane.
+        # Widgets inherit the styles, so it means all childs would be h1.
+        # To avoid redefining each child separately, an intermediate Pannel is created and defined as h2 (default style).
+        # This intermediate Pannel is the one exposed in the interface so that children can inherit a proper type.
+        fontSize = self.GetFont().GetPointSize()
+        h1Font = wx.Font(fontSize * 1.2, *wx_util.styles['h1'])  # Equivalent to the StaticTexts created with h1().
+        h2Font = wx.Font(fontSize, *wx_util.styles['h2'])  # Equivalent to the StaticTexts created with h2().
+        self.SetFont(h1Font)
+        if showBorders:
+            boxDetails = wx.StaticBox(self.GetPane(), -1, groupName)
+            self.firstLevelsizer = wx.StaticBoxSizer(boxDetails, wx.VERTICAL)
+        else:
+            self.firstLevelsizer = wx.BoxSizer(wx.VERTICAL)
+            self.firstLevelsizer.AddSpacer(10)
+        self.GetPane().SetSizer(self.firstLevelsizer)
+        
+        self.intermediateWindow = wx.Panel(self.GetPane())
+        self.intermediateWindow.SetFont(h2Font)
+        self.firstLevelsizer.Add(self.intermediateWindow, 0, wx.EXPAND | wx.LEFT, 10)
+        self.secondLevelSizer = wx.BoxSizer(wx.VERTICAL)
+        self.intermediateWindow.SetSizer(self.secondLevelSizer)
+
+        if groupDescription:
+            description = wx.StaticText(self.getParentForChilds(), label=groupDescription)
+            description.SetFont(h2Font)
+            self.getSizerForChilds().Add(description, 0,  wx.EXPAND | wx.LEFT, 10)
+
+        if not showBorders and groupName:
+            self.getSizerForChilds().Add(wx_util.horizontal_rule(self.getParentForChilds()), 0, wx.EXPAND | wx.LEFT, 10)
+
+        self.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self.on_change)
+
+    def on_change(self, event):
+        self.GetParent().Layout()
+        # self.GetParent().SetupScrolling(scroll_x=False, scrollToTop=False)
+
+    def getParentForChilds(self):
+        # return self.GetPane()
+        return self.intermediateWindow
+
+    def getSizerForChilds(self):
+        # return self.firstLevelsizer
+        return self.secondLevelSizer

--- a/gooey/gui/components/options_group.py
+++ b/gooey/gui/components/options_group.py
@@ -1,0 +1,27 @@
+import wx
+from gooey.gui.util import wx_util
+
+class OptionsGroup:
+    def __init__(self, parent, groupName, groupDescription, showBorders):
+        # determine the type of border , if any, the main sizer will use
+        self.parent = parent
+        if showBorders:
+            boxDetails = wx.StaticBox(parent, -1, groupName)
+            self.sizer = wx.StaticBoxSizer(boxDetails, wx.VERTICAL)
+        else:
+            self.sizer = wx.BoxSizer(wx.VERTICAL)
+            self.sizer.AddSpacer(10)
+            if groupName:
+                self.sizer.Add(wx_util.h1(parent, groupName), 0, wx.TOP | wx.BOTTOM | wx.LEFT, 8)
+        if groupDescription:
+            description = wx.StaticText(parent, label=groupDescription)
+            self.sizer.Add(description, 0,  wx.EXPAND | wx.LEFT, 10)
+        # apply an underline when a grouping border is not specified
+        if not showBorders and groupName:
+            self.sizer.Add(wx_util.horizontal_rule(parent), 0, wx.EXPAND | wx.LEFT, 10)
+
+    def getSizerForChilds(self):
+        return self.sizer
+
+    def getParentForChilds(self):
+        return self.parent

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -50,7 +50,8 @@ class UnsupportedConfiguration(Exception):
 group_defaults = {
     'columns': 2,
     'padding': 10,
-    'show_border': False
+    'show_border': False,
+    'collapsible': False
 }
 
 item_default = {


### PR DESCRIPTION
This change adds a new boolean group option called "collapsible".
When the option is set to True, the group arguments are wrapped in a CollapsiblePane which is folded at start.
This allows to expose avanced options to some users without complexifying too much the interface for average users.
By default, the option set to False to maintain legacy behavior.